### PR TITLE
refactor: use newer capture func

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = (function(undefined) {
     }
 
     if (err instanceof Error) {
-      this.client.captureError(err, options);
+      this.client.captureException(err, options);
       return callback(null);
     }
 
@@ -57,7 +57,7 @@ module.exports = (function(undefined) {
     convertedError.code = err.code;
     convertedError.signal = err.signal;
     convertedError.stack = err.stack;
-    this.client.captureError(convertedError, options);
+    this.client.captureException(convertedError, options);
     return callback(null);
   };
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "raven": "0.x"
+    "raven": "1.x.x"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
`captureError` has been deprecated. Use `captureException` instead.
See: https://github.com/getsentry/raven-node/releases/tag/0.11.0